### PR TITLE
fix(size): create meta package for dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_nav2_snap)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()
+

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_nav2_snap</name>
+  <version>0.0.0</version>
+  <description>meta package for ros2 nav2 snap dependencies</description>
+  <maintainer email="canonical-robotics-brand@canonical.com">ubuntu-robotics</maintainer>
+  <license>GPLv3</license>
+
+  <exec_depend>nav2_bringup</exec_depend>
+
+</package>
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,7 +95,7 @@ apps:
     daemon: simple
     install-mode: disable
     plugs: [network, network-bind]
-    extensions: [ros2-humble-ros-base]
+    extensions: [ros2-humble-desktop]
 
   navigation:
     command: usr/bin/navigation_launcher.sh
@@ -103,7 +103,7 @@ apps:
     daemon: simple
     install-mode: disable
     plugs: [network, network-bind]
-    extensions: [ros2-humble-ros-base]
+    extensions: [ros2-humble-desktop]
 
   reset-config-templates:
     command: usr/bin/reset_config.sh
@@ -115,15 +115,15 @@ apps:
     stop-command: usr/bin/save_map.sh
     post-stop-command: usr/bin/slam_post_stop.sh
     plugs: [network, network-bind]
-    extensions: [ros2-humble-ros-base]
+    extensions: [ros2-humble-desktop]
 
 parts:
   ros2-nav2:
-    plugin: nil
+    plugin: colcon
+    source: .
     stage-packages:
       - wget
       - libssl3
-      - ros-humble-nav2-bringup
 
   scripts:
     plugin: dump


### PR DESCRIPTION
Added a meta package, since the stage-packages are not managed by the content-sharing extension.

The snap went from 500 MB to 39MB.

I used the `desktop` variant since the `ros-base` one was giving a 415MB snap.