### PR TITLE
fix: inherit secrets so the snapstore credential get passed

### DIFF
--- a/.github/workflows/monthly.yaml
+++ b/.github/workflows/monthly.yaml
@@ -7,9 +7,11 @@ on:
 jobs:
   humble:
     uses: canonical/ros2-nav2-snap/.github/workflows/snap.yaml@humble
+    secrets: inherit
     with:
       git-ref: "humble"
   jazzy:
     uses: canonical/ros2-nav2-snap/.github/workflows/snap.yaml@jazzy
+    secrets: inherit
     with:
       git-ref: "jazzy"


### PR DESCRIPTION
Once the credential get passed, monthly builds will publish